### PR TITLE
Add GPT-4 scenario based on GPT-3 scenario + Fix AI scenarios URL generation for Github hosted tool

### DIFF
--- a/ai-scenarios.html
+++ b/ai-scenarios.html
@@ -106,7 +106,10 @@
 
       console.log(url)
 
-      window.open(url, '_blank');
+      if (window.location.hostname.includes("github.io")) {
+		window.open("/carbon-footprint-modeling-tool" + url, '_blank');
+	  } else {
+		window.open(url, '_blank');
     }
   </script>
 </body>

--- a/scenarios/gpt4-ruf-mortas-token.json
+++ b/scenarios/gpt4-ruf-mortas-token.json
@@ -1,0 +1,17 @@
+{
+  "title": "GPT-4 estimated using Llama 2",
+  "description": "In the absence of reliable data on the energy consumption of GPT-4, this information is extrapolated from the estimations made for GPT-3. The number of parameters of GPT-3 is 175 billion, whereas GPT-4 might have a much larger parameter count of <a href='https://the-decoder.com/gpt-4-architecture-datasets-costs-and-more-leaked/' target='_blank'>1.76 trillion</a>.<br/><br/>Therefore, we assume that submitting a query to GPT-4 requires <b>10x</b> more energy.",
+  "scopes": [
+    {
+      "level": "Scope 3",
+      "description": {},
+        "list": [
+        {
+          "type": "link",
+          "quantity": 10,
+          "scenario_id": "gpt-ruf-mortas-token"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add GPT-4 scenario based on GPT-3 scenario.

You can delete all the other gpt-4 scenarios because they don't use the same open model and the results are very different.
Also, the gpt4-ruf-mortas-2b scenario doesn't take into account the 0.5x factor needed to take into account completion and prompt tokens.